### PR TITLE
Disable Google analytics for anything but prod

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -6,7 +6,9 @@ import { AppContainer } from 'react-hot-loader'
 import ReactGA from 'react-ga'
 import { unregister } from './registerServiceWorker'
 
-ReactGA.initialize('UA-125271813-1')
+if (NPM_CONFIG_PRODUCTION === 'production') {
+  ReactGA.initialize('UA-125271813-1')
+}
 
 const render = (Component) => {
   ReactDOM.render((

--- a/app/index.js
+++ b/app/index.js
@@ -6,7 +6,7 @@ import { AppContainer } from 'react-hot-loader'
 import ReactGA from 'react-ga'
 import { unregister } from './registerServiceWorker'
 
-if (NPM_CONFIG_PRODUCTION === 'production') {
+if (process.env.NPM_CONFIG_PRODUCTION === 'production') {
   ReactGA.initialize('UA-125271813-1')
 }
 


### PR DESCRIPTION
I don't think that React-GA checks for prod, so lets do that ourselves.

This way I can check out http://studieresan.se/static/media/michel.9f380fb9.png without the skewing the statistics :heart_eyes: 