### PR TITLE
CV page/header fixups

### DIFF
--- a/app/components/Cv/styles.css
+++ b/app/components/Cv/styles.css
@@ -1,5 +1,5 @@
 .cv {
-  padding: 2rem;
+  padding: 6rem 2rem;
   display: flex;
   justify-content: center;
   height: 100%;

--- a/app/components/CvHeader/index.js
+++ b/app/components/CvHeader/index.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Logo from 'static/img/logo/black-frame.svg'
 import MemberImage from 'components/MemberImage'
 import styles from './styles.css'
 
@@ -11,20 +10,17 @@ function CvHeader({ user }) {
       <div className={styles.contactWrapper}>
         <MemberImage
           picture={user.picture}
-          size={100}
+          size={'100'}
           square
           round />
         <div className={styles.contact}>
-          <div>{user.firstName} {user.lastName}</div>
+          <div><b>{user.firstName} {user.lastName}</b></div>
           <div>{user.position} @ Studs</div>
           <div>Studying {user.master} @ KTH</div>
-          <div><a href={`mailto:${user.email}`}>{user.email}</a></div>
-          <div><a href={`tel:${user.phone}`}>{user.phone}</a></div>
+          {user.email && <div><a href={`mailto:${user.email}`}>{user.email}</a></div>}
+          {user.phone && <div><a href={`tel:${user.phone}`}>{user.phone}</a></div>}
           {user.linkedIn && <div><a href={user.linkedIn}>LinkedIn</a></div>}
         </div>
-      </div>
-      <div className={styles.logo}>
-        <img src={Logo} />
       </div>
     </div>
   )

--- a/app/components/CvHeader/styles.css
+++ b/app/components/CvHeader/styles.css
@@ -11,17 +11,7 @@
 .contact {
   align-self: center;
   font-size: 12px;
-  padding: 0 20px;
   flex: 2;
-}
-
-.logo {
-  margin-bottom: 20px;
-  align-self: top;
-}
-
-.logo > img {
-  height: 50px;
 }
 
 a {

--- a/app/components/CvHeader/styles.css
+++ b/app/components/CvHeader/styles.css
@@ -14,6 +14,6 @@
   flex: 2;
 }
 
-a {
+.contact a {
   text-decoration: underline;
 }

--- a/app/components/MasterDetail/styles.css
+++ b/app/components/MasterDetail/styles.css
@@ -7,10 +7,10 @@
   background-color: #FCFCFC;
   width: 250px;
   height: 100%;
+  padding-top: 16px;
 }
 
 .detail {
   flex: 2;
   height: 100%;
-  padding-top: 1rem;
 }

--- a/app/components/MemberImage/styles.css
+++ b/app/components/MemberImage/styles.css
@@ -3,6 +3,7 @@
   object-position: center 15%;
   max-width: 100%;
   max-height: 100%;
+  margin-right: 20px;
 }
 
 .round {

--- a/app/containers/CvEdit/styles.css
+++ b/app/containers/CvEdit/styles.css
@@ -1,5 +1,4 @@
 .cvEdit {
-  padding: 6rem 2rem;
   background: #F7DDC9;
 }
 

--- a/app/containers/Members/styles.css
+++ b/app/containers/Members/styles.css
@@ -1,7 +1,3 @@
-.members {
-  padding-top: 16px;
-}
-
 .listHeader {
   background: #F7DDC9;
   color: black;


### PR DESCRIPTION
Some general fix ups to the CV Header and CV page, including fixing the CV header cutting off on mobile. 

Other fixes include removing double Studs logo, aligning "edit CV" and "view CV" views, aligning CV header with the rest of the content, and fixing an issue with link decoration styling also applying to other pages.