### PR TITLE
Add onClick listener to selection

### DIFF
--- a/app/components/EventEdit/index.js
+++ b/app/components/EventEdit/index.js
@@ -125,6 +125,7 @@ class EventEdit extends React.Component {
             name='companyName'
             placeholder='Company'
             value={event.companyName || ''}
+            onClick={this.handleChange}
             onChange={this.handleChange}>
             <option key='none'
               disabled>


### PR DESCRIPTION
Previously there was only an onChange listener. This would
not work unless there were > 1 companies to choose from, because there
would be no change. This commit adds an onClick listener as well so the
selection works even if there's only one company to choose.