### PR TITLE
Fix event CSS issues

### DIFF
--- a/app/components/EventDetail/styles.css
+++ b/app/components/EventDetail/styles.css
@@ -1,5 +1,5 @@
 .eventDetail {
-  padding: 30px;
+  padding: 0px 30px 30px 30px;
   height: 100%;
   overflow: auto;
 }

--- a/app/components/PublicEventMenu/styles.css
+++ b/app/components/PublicEventMenu/styles.css
@@ -1,14 +1,12 @@
 .publicEventMenu {
-  display: flex;
-  flex-direction: column;
-  position: fixed;
-  z-index: 10;
+  position: sticky;
+  top: 0;
   width: 200px;
-  background: #F7DDC9;
-  height: 100%;
+  height: 100vh;
   padding-left: 1.5rem;
-  padding-top: 4rem;
-  overflow-y: auto;
+  padding-top: 20px;
+  margin-top: calc(var(--header-height) - 20px);
+  overflow-y: scroll;
 }
 
 .publicEventMenu > h2 {
@@ -39,11 +37,14 @@
     padding-left: 0;
     padding-bottom: 46px;
     width: auto;
+    height: auto;
   }
+
   .publicEventMenu > h2 {
     font-size: 28px;
     text-align: center;
   }
+
   .publicEventMenu a {
     text-align: center;
   }

--- a/app/containers/Events/styles.css
+++ b/app/containers/Events/styles.css
@@ -1,5 +1,5 @@
 .events {
-  padding-top: 56px;
+  padding-top: var(--header-height);
   height: 100vh;
 }
 
@@ -24,7 +24,7 @@
 }
 
 .actions a:hover {
-  color: #90CE9C;
+  color: #90ce9c;
 }
 
 .list {
@@ -33,6 +33,8 @@
 }
 
 .listHeader {
+  position: sticky;
+  top: 0px;
   display: flex;
   justify-content: space-between;
   padding: 10px;
@@ -41,7 +43,7 @@
   font-size: 12px;
   height: 40px;
   align-items: center;
-  background-color: #F7DDC9;
+  background-color: #f7ddc9;
 }
 
 .listContainer {

--- a/app/index.css
+++ b/app/index.css
@@ -11,6 +11,12 @@
   --header-height: 110px;
 }
 
+@media (max-width: 1024px) {
+  :root {
+    --header-height: 90px;
+  }
+}
+
 html,
 body {
   margin: 0;


### PR DESCRIPTION
Temporary fix for the /events page so the header doesn't overlap the other content:

<img width="1435" alt="image" src="https://user-images.githubusercontent.com/16100194/48512413-bd45c600-e859-11e8-9d62-8e4a0402b19a.png">
