### PR TITLE
Event detail and edit fixes

### DIFF
--- a/app/api.js
+++ b/app/api.js
@@ -248,6 +248,7 @@ const EVENT_FIELDS = `
   location
   pictures
   published
+  responsible
 `
 
 export function fetchEvents() {

--- a/app/components/Button/index.js
+++ b/app/components/Button/index.js
@@ -10,6 +10,7 @@ function Button({
   full,
   wrapper,
   disabled,
+  rounded,
   onClick,
   children,
 }) {
@@ -18,6 +19,7 @@ function Button({
       [styles[`${color}`]]: color,
       [styles.disabled]: disabled,
       [styles.full]: full,
+      [styles.rounded]: rounded,
     },
     styles.button,
     className
@@ -48,6 +50,7 @@ Button.propTypes = {
   full: PropTypes.bool,
   wrapper: PropTypes.bool,
   disabled: PropTypes.bool,
+  rounded: PropTypes.bool,
   onClick: PropTypes.func,
   children: PropTypes.node,
 }
@@ -57,6 +60,7 @@ Button.defaultProps = {
   type: 'button',
   full: false,
   wrapper: false,
+  rounded: false,
 }
 
 export default Button

--- a/app/components/Button/styles.css
+++ b/app/components/Button/styles.css
@@ -6,6 +6,7 @@
   justify-content: center;
   align-items: center;
   transition: background 0.2s, color 0.2s;
+  outline: none;
 }
 
 .default {

--- a/app/components/Button/styles.css
+++ b/app/components/Button/styles.css
@@ -15,7 +15,7 @@
 }
 
 .rounded {
-  border-radius: 9999px;
+  border-radius: 100px;
 }
 
 .default:hover {

--- a/app/components/Button/styles.css
+++ b/app/components/Button/styles.css
@@ -9,12 +9,16 @@
 }
 
 .default {
-  background: #303B4B;
+  background: #303b4b;
   color: white;
 }
 
+.rounded {
+  border-radius: 9999px;
+}
+
 .default:hover {
-  color: #F7DDC9;
+  color: #f7ddc9;
 }
 
 .full {
@@ -23,39 +27,39 @@
 }
 
 .danger {
-  background: #FCF0E8;
-  color: #DD696D;
+  background: #fcf0e8;
+  color: #dd696d;
 }
 
 .danger:hover {
-  background: #DD696D;
-  color: #FCF0E8;
+  background: #dd696d;
+  color: #fcf0e8;
 }
 
 .bright {
-  background: #F7DDC9;
+  background: #f7ddc9;
   color: black;
 }
 
 .bright:hover {
   background: black;
-  color: #F7DDC9;
+  color: #f7ddc9;
 }
 
 .dark {
   background: black;
-  color: #F7DDC9;
+  color: #f7ddc9;
 }
 
 .disabled {
-  background: #CCC;
+  background: #ccc;
   color: #666;
   pointer-events: none;
 }
 
 .icon {
   background: none;
-  color: #303B4B;
+  color: #303b4b;
   padding: 0;
 }
 
@@ -63,4 +67,10 @@
   margin: 1rem 0;
   display: flex;
   justify-content: center;
+}
+
+.close {
+  position: absolute;
+  top: 0;
+  right: 0;
 }

--- a/app/components/EventDetail/index.js
+++ b/app/components/EventDetail/index.js
@@ -67,14 +67,14 @@ class EventDetail extends Component {
                 onClick={() => this.toggleEditing()}
                 rounded={true}
               >
-                Edit
+                <FormattedMessage {...messages.edit} />
               </Button>
               <Button
                 color='danger'
                 onClick={() => onRemoveEvent(event.id)}
                 rounded={true}
               >
-                Delete
+                <FormattedMessage {...messages.delete} />
               </Button>
             </div>
           )}
@@ -87,13 +87,17 @@ class EventDetail extends Component {
             </div>
           )}
           <div>
-            <h4>Date</h4>
+            <h4>
+              <FormattedMessage {...messages.date} />
+            </h4>
             <div>
               {event.date && moment(event.date).format('MMM DD, HH:mm')}
             </div>
           </div>
           <div>
-            <h4>Location</h4>
+            <h4>
+              <FormattedMessage {...messages.location} />
+            </h4>
             <a
               href={`https://www.google.com/maps/search/?api=1&query=
               + ${encodeURIComponent(event.location)}`}
@@ -104,7 +108,9 @@ class EventDetail extends Component {
           </div>
           {user && user.type === 'studs_member' && (
             <div>
-              <h4>Surveys</h4>
+              <h4>
+                <FormattedMessage {...messages.surveys} />
+              </h4>
               <div>
                 <IndicatorIcon ok={event.beforeSurveyReplied || false} />
                 <A target='_blank' href={event.beforeSurveys[0] || ''}>

--- a/app/components/EventDetail/index.js
+++ b/app/components/EventDetail/index.js
@@ -8,6 +8,7 @@ import Button from 'components/Button'
 import { Chart } from 'react-google-charts' // TODO replace with chart.js
 import { hasEventPermission } from 'users'
 
+import moment from 'moment'
 import styles from './styles.css'
 import A from 'components/A'
 import IndicatorIcon from 'components/IndicatorIcon'
@@ -46,42 +47,56 @@ class EventDetail extends Component {
     return (
       <div className={styles.eventDetail}>
         {this.state.isEditing && (
-          <Lightbox>
+          <Lightbox
+            toggleLightbox={() => {
+              this.toggleEditing()
+            }}
+          >
             <EventEdit
               event={event}
-              toggleEditing={() => {
-                this.toggleEditing()
-              }}
+              toggleLightbox={() => this.toggleEditing()}
             />
           </Lightbox>
         )}
         <div className={styles.head}>
-          <h2>
-            <FormattedMessage {...messages.event} />: {event.companyName} -{' '}
-            {event.date && event.date.toString()}
-          </h2>
+          <h2>{event.companyName}</h2>
           {hasEventPermission(user) && (
             <div className={styles.buttonRow}>
-              <Button color='bright' onClick={() => this.toggleEditing()}>
+              <Button
+                color='bright'
+                onClick={() => this.toggleEditing()}
+                rounded={true}
+              >
                 Edit
               </Button>
-              <Button color='danger' onClick={() => onRemoveEvent(event.id)}>
+              <Button
+                color='danger'
+                onClick={() => onRemoveEvent(event.id)}
+                rounded={true}
+              >
                 Delete
               </Button>
             </div>
           )}
         </div>
         <div className={styles.info}>
+          {event && event.responsible && (
+            <div>
+              <h4>Responsible</h4>
+              <div>{event.responsible}</div>
+            </div>
+          )}
           <div>
-            <h4>Company</h4>
-            <div>{event.companyName}</div>
+            <h4>Date</h4>
+            <div>
+              {event.date && moment(event.date).format('MMM DD, HH:mm')}
+            </div>
           </div>
           <div>
             <h4>Location</h4>
             <a
-              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
-                event.location
-              )}`}
+              href={`https://www.google.com/maps/search/?api=1&query=
+              + ${encodeURIComponent(event.location)}`}
               target='_blank'
             >
               {event.location}
@@ -91,13 +106,13 @@ class EventDetail extends Component {
             <div>
               <h4>Surveys</h4>
               <div>
-                <IndicatorIcon ok={event.beforeSurveyReplied} />
+                <IndicatorIcon ok={event.beforeSurveyReplied || false} />
                 <A target='_blank' href={event.beforeSurveys[0] || ''}>
                   <FormattedMessage {...messages.before} />
                 </A>
               </div>
               <div>
-                <IndicatorIcon ok={event.afterSurveyReplied} />
+                <IndicatorIcon ok={event.afterSurveyReplied || false} />
                 <A target='_blank' href={event.afterSurveys[0] || ''}>
                   <FormattedMessage {...messages.after} />
                 </A>

--- a/app/components/EventDetail/messages.js
+++ b/app/components/EventDetail/messages.js
@@ -34,4 +34,28 @@ export default defineMessages({
     id: 'app.components.EventDetail.missing',
     defaultMessage: 'Missing Surveys',
   },
+  date: {
+    id: 'app.containers.Events.date',
+    defaultMessage: 'Date',
+  },
+  location: {
+    id: 'app.components.EventEdit.location',
+    defaultMessage: 'Location',
+  },
+  responsible: {
+    id: 'app.components.EventEdit.responsible',
+    defaultMessage: 'Responsible',
+  },
+  surveys: {
+    id: 'app.components.EventDetail.surveys',
+    defaultMessage: 'Surveys',
+  },
+  edit: {
+    id: 'app.components.EventDetail.edit',
+    defaultMessage: 'Edit',
+  },
+  delete: {
+    id: 'app.components.EventDetail.delete',
+    defaultMessage: 'Delete',
+  },
 })

--- a/app/components/EventEdit/index.js
+++ b/app/components/EventEdit/index.js
@@ -129,6 +129,15 @@ class EventEdit extends React.Component {
           />
         </div>
         <div className={styles.inputLabel}>
+          <FormattedMessage {...messages.responsible} />
+        </div>
+        <input
+          name='responsible'
+          placeholder=''
+          value={event.responsible || ''}
+          onChange={this.handleChange}
+        />
+        <div className={styles.inputLabel}>
           <FormattedMessage {...messages.company} />
         </div>
         <div className={styles.selectContainer}>

--- a/app/components/EventEdit/index.js
+++ b/app/components/EventEdit/index.js
@@ -61,6 +61,7 @@ class EventEdit extends React.Component {
     const { save, event } = this.props
     if (event.companyName) {
       save(event)
+      this.props.toggleLightbox()
     } else {
       alert('You must select a company before saving.')
     }
@@ -82,7 +83,6 @@ class EventEdit extends React.Component {
       events: { saving, saved },
       removePicture,
       removeSurvey,
-      toggleEditing,
     } = this.props
     const companyOption = companyName => (
       <option key={companyName} value={companyName || ''}>
@@ -104,28 +104,31 @@ class EventEdit extends React.Component {
 
     return (
       <div className={styles.eventEdit}>
-        <Button
-          type='button'
-          className={styles.close}
-          onClick={() => toggleEditing()}
-        >
-          <span>X</span>
-        </Button>
         <div className={styles.head}>
-          <h2>
-            Event: {event.companyName} -{event.date && event.date.toString()}
-          </h2>
-          {!saving && !saved && (
-            <Button
-              onClick={this.handleSave}
-              type='submit'
-              className='btn-bright'
-            >
-              <FormattedMessage {...messages.save} />
-            </Button>
-          )}
+          <h2>{event.companyName}</h2>
+          <Button
+            onClick={this.handleSave}
+            type='submit'
+            color={'default'}
+            disabled={!(!saving && !saved)}
+            rounded={true}
+          >
+            <FormattedMessage {...messages.save} />
+          </Button>
         </div>
-        <div className='input-label'>
+        <div className={styles.inputLabel}>
+          <FormattedMessage {...messages.published} />
+          <input
+            className={styles.checkbox}
+            type='checkbox'
+            name='published'
+            checked={event.published}
+            onChange={e =>
+              this.update({ published: !!e.target.checked }, event.id)
+            }
+          />
+        </div>
+        <div className={styles.inputLabel}>
           <FormattedMessage {...messages.company} />
         </div>
         <div className={styles.selectContainer}>
@@ -142,7 +145,7 @@ class EventEdit extends React.Component {
             {companies && companies.map(companyOption)}
           </select>
         </div>
-        <div className='input-label'>
+        <div className={styles.inputLabel}>
           <FormattedMessage {...messages.date} />
         </div>
         <input
@@ -151,7 +154,7 @@ class EventEdit extends React.Component {
           value={moment(event.date).format('YYYY-MM-DDTHH:mm')}
           onChange={this.handleChange}
         />
-        <div className='input-label'>
+        <div className={styles.inputLabel}>
           <FormattedMessage {...messages.location} />
         </div>
         <input
@@ -160,7 +163,7 @@ class EventEdit extends React.Component {
           value={event.location || ''}
           onChange={this.handleChange}
         />
-        <div className='input-label'>
+        <div className={styles.inputLabel}>
           <FormattedMessage {...messages.publicDescription} />
         </div>
         <Textarea
@@ -169,7 +172,7 @@ class EventEdit extends React.Component {
           onChange={this.handleChange}
           value={event.publicDescription || ''}
         />
-        <div className='input-label'>
+        <div className={styles.inputLabel}>
           <FormattedMessage {...messages.privateDescription} />
         </div>
         <Textarea
@@ -178,7 +181,7 @@ class EventEdit extends React.Component {
           onChange={this.handleChange}
           value={event.privateDescription || ''}
         />
-        <div className='input-label'>
+        <div className={styles.inputLabel}>
           <FormattedMessage {...messages.beforeSurvey} />
         </div>
         {event.beforeSurveys.map(surveyListItem('beforeSurveys'))}
@@ -192,7 +195,7 @@ class EventEdit extends React.Component {
             this.addSurvey(e.target.name, e.target.value, event)
           }
         />
-        <div className='input-label'>
+        <div className={styles.inputLabel}>
           <FormattedMessage {...messages.afterSurvey} />
         </div>
         {event.afterSurveys.map(surveyListItem('afterSurveys'))}
@@ -206,7 +209,7 @@ class EventEdit extends React.Component {
             this.addSurvey(e.target.name, e.target.value, event)
           }
         />
-        <div className='input-label'>
+        <div className={styles.inputLabel}>
           <FormattedMessage {...messages.pictures} />
         </div>
         <div className={styles.eventPictures}>
@@ -220,17 +223,6 @@ class EventEdit extends React.Component {
           ))}
         </div>
         <input type='file' name='picture' onChange={this.handleChange} />
-        <div className='input-label'>
-          <FormattedMessage {...messages.published} />
-        </div>
-        <input
-          type='checkbox'
-          name='published'
-          checked={event.published}
-          onChange={e =>
-            this.update({ published: !!e.target.checked }, event.id)
-          }
-        />
       </div>
     )
   }
@@ -246,7 +238,7 @@ EventEdit.propTypes = {
   addSurvey: PropTypes.func.isRequired,
   removeSurvey: PropTypes.func.isRequired,
   events: PropTypes.object.isRequired,
-  toggleEditing: PropTypes.func.isRequired,
+  toggleLightbox: PropTypes.func.isRequired,
 }
 
 const mapStateToProps = selectEvents()

--- a/app/components/EventEdit/index.js
+++ b/app/components/EventEdit/index.js
@@ -110,7 +110,7 @@ class EventEdit extends React.Component {
             onClick={this.handleSave}
             type='submit'
             color={'default'}
-            disabled={!(!saving && !saved)}
+            disabled={saving && saved}
             rounded={true}
           >
             <FormattedMessage {...messages.save} />

--- a/app/components/EventEdit/index.js
+++ b/app/components/EventEdit/index.js
@@ -110,7 +110,7 @@ class EventEdit extends React.Component {
             onClick={this.handleSave}
             type='submit'
             color={'default'}
-            disabled={saving && saved}
+            disabled={saving || saved}
             rounded={true}
           >
             <FormattedMessage {...messages.save} />

--- a/app/components/EventEdit/messages.js
+++ b/app/components/EventEdit/messages.js
@@ -45,4 +45,8 @@ export default defineMessages({
     id: 'app.components.EventEdit.published',
     defaultMessage: 'Published',
   },
+  responsible: {
+    id: 'app.components.EventEdit.responsible',
+    defaultMessage: 'Responsible',
+  },
 })

--- a/app/components/EventEdit/styles.css
+++ b/app/components/EventEdit/styles.css
@@ -1,14 +1,18 @@
 .eventEdit {
-  padding: 30px;
+  padding: 50px;
   height: 100%;
-  overflow: auto;
   width: 50%;
+  max-width: 640px;
   background-color: white;
   position: relative;
+  margin-top: 50px;
+  overflow: scroll;
+  padding-bottom: 75px;
 }
 
 .head {
   display: flex;
+  flex-direction: row;
   justify-content: space-between;
   flex-wrap: wrap;
 }
@@ -16,18 +20,24 @@
 .head > h2 {
   margin-top: 0;
   letter-spacing: 2px;
+  margin-bottom: 0;
 }
 
 .eventEdit input {
-  width: 100%;
-  max-width: 500px;
+  width: 60%;
+  display: inline-block;
+  padding: 0;
+  font-family: var(--body-font);
+}
+
+.eventEdit .checkbox {
+  width: 40px;
 }
 
 .eventEdit textarea {
   border: 1px solid black;
   padding: 6px;
   width: 100%;
-  max-width: 500px;
 }
 
 .eventEdit textarea:focus {
@@ -38,6 +48,10 @@
   border: 1px solid black;
   padding: 5px;
   width: fit-content;
+}
+
+.selectContainer select {
+  font-family: var(--body-font);
 }
 
 .import {
@@ -58,4 +72,22 @@
   position: absolute;
   top: 0;
   right: 0;
+  z-index: 2;
+}
+
+.inputLabel {
+  padding-top: 20px;
+}
+
+.rounded {
+  border-radius: 20px;
+}
+
+@media (max-width: 795px) {
+  .eventEdit {
+    margin-top: 0px;
+    min-width: 100%;
+    padding-left: 15%;
+    padding-right: 15%;
+  }
 }

--- a/app/components/EventListItem/index.js
+++ b/app/components/EventListItem/index.js
@@ -10,7 +10,7 @@ import styles from './styles.css'
 function EventListItem(props) {
   const { event, user, isSelected } = props
   const { date } = event
-  const dateString = date && moment(date).format('HH:mm, MMM DD')
+  const dateString = date && moment(date).format('MMM DD, HH:mm')
   const classes = classnames(styles.eventListItem, {
     [styles.selected]: isSelected,
   })

--- a/app/components/Lightbox/index.js
+++ b/app/components/Lightbox/index.js
@@ -1,11 +1,34 @@
-import React, {Component} from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import styles from './styles.css'
+import Button from 'components/Button'
 
 class Lightbox extends Component {
+  constructor(props) {
+    super(props)
+  }
+
+  clickBackgroundToClose = e => {
+    if (e.target.className === styles.lightbox) {
+      this.props.toggleLightbox()
+    }
+  }
+
   render() {
     return (
-      <div className={styles.lightbox}>
+      <div
+        className={styles.lightbox}
+        onClick={e => {
+          this.clickBackgroundToClose(e)
+        }}
+      >
+        <Button
+          type='button'
+          className={styles.close}
+          onClick={() => this.props.toggleLightbox()}
+        >
+          <span>X</span>
+        </Button>
         {this.props.children}
       </div>
     )
@@ -13,7 +36,8 @@ class Lightbox extends Component {
 }
 
 Lightbox.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.object.isRequired,
+  toggleLightbox: PropTypes.func.isRequired,
 }
 
 export default Lightbox

--- a/app/components/Lightbox/index.js
+++ b/app/components/Lightbox/index.js
@@ -4,10 +4,6 @@ import styles from './styles.css'
 import Button from 'components/Button'
 
 class Lightbox extends Component {
-  constructor(props) {
-    super(props)
-  }
-
   clickBackgroundToClose = e => {
     if (e.target.className === styles.lightbox) {
       this.props.toggleLightbox()

--- a/app/components/Lightbox/styles.css
+++ b/app/components/Lightbox/styles.css
@@ -1,14 +1,21 @@
 .lightbox {
-    height: 100vh;
-    width: 100vw;
-    background-color: rgba(43, 42, 43, 0.5);
-    position: absolute;
-    top: 0;
-    left: 0;
-    z-index: 100;
+  height: 100vh;
+  width: 100vw;
+  background-color: rgba(43, 42, 43, 0.5);
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 10;
 
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding-top: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.close {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 11;
 }

--- a/app/containers/Events/reducer.js
+++ b/app/containers/Events/reducer.js
@@ -27,6 +27,7 @@ const newEvent = {
   location: '',
   pictures: [],
   published: false,
+  responsible: '',
 }
 
 const initialState = fromJS({

--- a/app/containers/ScrollContainer/index.js
+++ b/app/containers/ScrollContainer/index.js
@@ -18,7 +18,7 @@ class ScrollContainer extends Component {
 }
 
 ScrollContainer.propTypes = {
-  location: PropTypes.string.isRequired,
+  location: PropTypes.object.isRequired,
   children: PropTypes.node.isRequired,
 }
 

--- a/app/translations/se.json
+++ b/app/translations/se.json
@@ -144,8 +144,40 @@
     "message": "Publicerad"
   },
   {
+    "id": "app.components.EventEdit.responsible",
+    "message": "Ansvarig"
+  },
+  {
     "id": "app.components.EventDetail.event",
     "message": "Event"
+  },
+  {
+    "id": "app.components.EventDetail.edit",
+    "message": "Redigera"
+  },
+  {
+    "id": "app.components.EventDetail.delete",
+    "message": "Ta bort"
+  },
+  {
+    "id": "app.components.EventDetail.surveys",
+    "message": "Enkäter"
+  },
+  {
+    "id": "app.components.EventDetail.before",
+    "message": "Före"
+  },
+  {
+    "id": "app.components.EventDetail.after",
+    "message": "Efter"
+  },
+  {
+    "id": "app.components.EventDetail.description",
+    "message": "Beskrivning"
+  },
+  {
+    "id": "app.components.EventDetail.privateDescription",
+    "message": "Privat Beskrivning"
   },
   {
     "id": "app.containers.Navbar.internalevents",


### PR DESCRIPTION
Some more fixes to the event page:

The lightbox can now be closed by either clicking on the side of the content, or clicking the top right button which has been moved.

There is a field for who is responsible for the event.

General beautifications of the buttons, distances, fonts, etc.

<img width="1680" alt="screenshot 2018-12-03 at 13 21 54" src="https://user-images.githubusercontent.com/13571496/49373439-79c6d500-f6fe-11e8-9068-ec745f381076.png">
<img width="1680" alt="screenshot 2018-12-03 at 13 22 03" src="https://user-images.githubusercontent.com/13571496/49373442-7c292f00-f6fe-11e8-86d7-ec60c244f594.png">
