### PR TITLE
Fix navbar visible in print

### DIFF
--- a/app/containers/Navbar/index.js
+++ b/app/containers/Navbar/index.js
@@ -1,38 +1,23 @@
 // @flow
 import React from 'react'
-import { Switch, Route, withRouter } from 'react-router-dom'
-import { connect } from 'react-redux'
+import { Switch, Route } from 'react-router-dom'
 import Nav from './Nav'
 
 const LightNav = props => <Nav {...props} invert />
 
-type Props = {|
-  +printMode: boolean,
-|}
-
 /**
  * Use a different variation of the navbar depending on which
  * page you are in currently.
- * @return {null} or a component
  */
-function Navbar({ printMode }: Props) {
-  if (printMode) {
-    return null
-  }
+function Navbar() {
   return (
     <Switch>
-      <Route exact path='/' render={LightNav} />
-      <Route path='/login' render={LightNav} />
-      <Route path='/event-feedback' render={null} />
+      <Route exact path='/' component={LightNav} />
+      <Route path='/login' component={LightNav} />
+      <Route path='/events/:eventId/event-feedback' render={() => null} />
       <Route component={Nav} />
     </Switch>
   )
 }
 
-const mapStateToProps = state => {
-  return {
-    printMode: state.getIn(['global', 'printMode']),
-  }
-}
-
-export default withRouter(connect(mapStateToProps)(Navbar))
+export default Navbar

--- a/app/containers/Navbar/index.js
+++ b/app/containers/Navbar/index.js
@@ -10,10 +10,13 @@ const LightNav = props => <Nav {...props} invert />
  * page you are in currently.
  */
 function Navbar() {
+  // For some reason, using `component` instead of `render` makes
+  // the transition from light to dark and vice versa janky, but it's
+  // smooth when using render
   return (
     <Switch>
-      <Route exact path='/' component={LightNav} />
-      <Route path='/login' component={LightNav} />
+      <Route exact path='/' render={LightNav} />
+      <Route path='/login' render={LightNav} />
       <Route path='/events/:eventId/event-feedback' render={() => null} />
       <Route component={Nav} />
     </Switch>

--- a/app/containers/Navbar/styles.css
+++ b/app/containers/Navbar/styles.css
@@ -166,3 +166,9 @@
     transform: translateY(-30px);
   }
 }
+
+@media print {
+  .navbar {
+    display: none;
+  }
+}


### PR DESCRIPTION
So the error was that the route for the event feedback page had changed, but the navbar component wasn't modified accordingly (went from `/event-feedback` to `/events/:eventId/event-feedback`).

I also added a bit of CSS to ensure the navbar is never visible when printing, bc I don't think that's ever what you want. With the newly added CSS, I could also simplify the navbar component a bit.